### PR TITLE
Suggestions for structuring the project

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,49 @@
+# Temporary and binary files
+*~
+*.py[cod]
+*.so
+*.cfg
+!.isort.cfg
+!setup.cfg
+*.orig
+*.log
+*.pot
+__pycache__/*
+.cache/*
+.*.swp
+*/.ipynb_checkpoints/*
+
+# Project files
+.ropeproject
+.project
+.pydevproject
+.settings
+.idea
+tags
+
+# Package files
+*.egg
+*.eggs/
+.installed.cfg
+*.egg-info
+
+# Unittest and coverage
+htmlcov/*
+.coverage
+.tox
+junit.xml
+coverage.xml
+.pytest_cache/
+
+# Build and docs folder/files
+build/*
+dist/*
+sdist/*
+docs/api/*
+docs/_rst/*
+docs/_build/*
+cover/*
+MANIFEST
+
+# Per-project virtualenvs
+.venv*/

--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,6 @@ MANIFEST
 
 # Per-project virtualenvs
 .venv*/
+
+# User-specific files
+.bamrc

--- a/AUTHORS.rst
+++ b/AUTHORS.rst
@@ -1,0 +1,5 @@
+============
+Contributors
+============
+
+* Russell Sutherland <russell.sutherland@utoronto.ca>

--- a/README.md
+++ b/README.md
@@ -18,7 +18,6 @@ $ cd bamcli
 $ python3 -m venv `pwd`/venv
 $ . venv/bin/activate
 (venv) $ pip install --upgrade pip
-(venv) $ pip install click requests
 (venv) $ pip install --editable .
 ```
 

--- a/README.md
+++ b/README.md
@@ -1,29 +1,31 @@
-## bamcli
+# bamcli
 
-bamcli is a CLI (Command Line Interface) to BAM (BlueCat Address Manager). It uses the BAM Python API.
+blucat_am is a python interface to the BlueCat Address Manager software (https://www.bluecatnetworks.com/platform/management/bluecat-address-manager/). It offers both an API and a CLI to simplify management of resources in a BlueCat Address Manager installation
 
-## Installation
 
-Download the source code from Github:
+## Getting Started
 
-<pre><code>
+To get started, download the source code from Github:
+
+```bash
 $ git clone https://github.com/quistian/bamcli.git
-</code></pre>
+```
 
 Set up a Python3 virtual environment for bamcli to run in:
 
-<pre><code>
+```bash
 $ cd bamcli
 $ python3 -m venv `pwd`/venv
 $ . venv/bin/activate
 (venv) $ pip install --upgrade pip
 (venv) $ pip install click requests
 (venv) $ pip install --editable .
-</code></pre>
+```
+
 
 Customize your Unix shell (this documentation assumes /bin/sh, /bin/bash or /bin/zsh) environment to set the BAM URL, Username and Password.
 
-<pre><code>
+```bash
 (venv) $ cat .example_bamrc
 export BAM_USER=fred
 export BAM_PW='Flintstones_R_4ever!'
@@ -32,16 +34,16 @@ export BAM_API_URL='https://bam.bigcorp.ca/Services/REST/v1/'
 (venv) $ mv .example_bamrc .bamrc
 (venv) $ vi .bamrc
 (venv) $ . .bamrc
-</code></pre>
+```
 
 The BAM CLI interface will not work with out these SHELL variables being set which serve as your credentials to the BAM.
 
 When finished with the bamcli session, you can exit the Python virtual environment as follows:
 
-<pre><code>
+```bash
 (venv) $ deactivate
 $
-</code></pre>
+```
 
 
 ## Description
@@ -62,43 +64,44 @@ At present the CLI understands four types of DNS Resource Records:
 
 The general bamcli syntax is as follows:
 
-<pre><code>
-<b>bamcli</b> <i>action</i> <i>fqdn</i> <i>RR_type</i> <i>value[,value,value]</i> [<i>ttl</i>]
+<pre><code><b>bamcli</b> <i>action</i> <i>fqdn</i> <i>RR_type</i> <i>value[,value,value]</i> [<i>ttl</i>]
 </code></pre>
 
 Where: <br>
 
-<i>action</i> is one of the above mentioned four editing operators:
+*action* is one of the above mentioned four editing operators:
 
 * add -> adds RRs to the DNS zone. For A records multiple values are permitted.
 * delete/remove -> deletes RRs from the DNS zone. Like A records, multiple values are permitted.
 * update -> updates the values of a given fqdn. All existing data is effectively deleted
 * view/list -> shows the current state of the DNS data
 
-* <i>fqdn</i> is the Fully Qualified Domain Name of the RR.
+* *fqdn* is the Fully Qualified Domain Name of the RR.
 
-* <i>RR_type</i> is one of: A, CNAME, TXT, MX
+* *RR_type* is one of: A, CNAME, TXT, MX
  
-* <i>value</i> is the data associated with the respective FQDN and RRtype.
+* *value* is the data associated with the respective FQDN and RRtype.
 
-<pre><code>
+
 Note: For TXT records the value must be surrounded by single or double quotes.
       For MX records the priority is optional and should be given after the value, separated by a comma.
       The default priority is 10.
       
-      E.g.
-      bamcli add txt.zip.bigcorp.ca TXT 'Sam I am!'
-      bamcli add mx.zip.bigcorp.ca MX mailer.zip.bigcorp.ca
-      bamcli add mx.zip.bigcorp.ca MX secondary.zip.bigcorp.ca:20
-</code></pre>
+E.g.
+```bash
+bamcli add txt.zip.bigcorp.ca TXT 'Sam I am!'
+bamcli add mx.zip.bigcorp.ca MX mailer.zip.bigcorp.ca
+bamcli add mx.zip.bigcorp.ca MX secondary.zip.bigcorp.ca:20
+```
 
 ## Examples
 
-<h3> Adding Resource Records</h3>
+### Adding Resource Records
   
 First we shall ADD some data to our zone: zip.bigcorp.ca to our network: 10.10.0.0/24
 
-<pre><code>
+
+```bash
 (venv) $ bamcli add red.zip.bigcorp.ca  A 10.10.0.100
 (venv) $ bamcli add blue.zip.bigcorp.ca A 10.10.10.10
 (venv) $ bamcli add blue.zip.bigcorp.ca A 10.10.2.2
@@ -107,47 +110,48 @@ First we shall ADD some data to our zone: zip.bigcorp.ca to our network: 10.10.0
 (venv) $ bamcli add rouge.zip.bigcorp.ca CNAME red.zip.bigcorp.ca
 (venv) $ bamcli add note.zip.bigcorp.ca TXT "Superman and Batman"
 (venv) $ bamcli add zip.bigcorp.ca MX 10,smtp.zip.bigcorp.ca
-</code></pre>
+```
+
 
 Records can also be added to the top level:
 
-<pre><code>
+```bash
 (venv) $ bamcli add zip.bigcorp.ca MX 10,smtp.zip.bigcorp.ca
 (venv) $ bamcli add zip.bigcorp.ca A 10.10.1.1
-</code></pre>
+```
 
 Time to Live values can be assigned on a per RR basis (the default being 86400 seconds/1 day) by adding a numeric value as the last argument:
 
-<pre><code>
+```bash
 (venv) $ bamcli add tmp.zip.bigcorp.ca A 10.10.7.7 3600
-</code></pre>
+```
 
-<h3> Updating DNS data </h3>
+### Updating DNS data
 
-The <i>update</i> action is similar in function to deleting all values associated with a FQDN of a given RRtype and then replacing them with the new ones given.
+The *update* action is similar in function to deleting all values associated with a FQDN of a given RRtype and then replacing them with the new ones given.
 
 E.g.
 
-<pre><code>
+```bash
 (venv) $ bamcli update zip.bigcorp.ca. A 10.10.10.1,10.10.10.2
 Updated RR as follows:
 zip.bigcorp.ca  IN  A  10.10.10.1
 zip.bigcorp.ca  IN  A  10.10.10.2
-</code></pre>
+```
 
 Will remove any and all A records associated with zip.bigcorp.ca and add two new one. The result will be:
 
-<pre><code>
+```bash
 (venv) $ bamcli view zip.bigcorp.ca A
 zip.bigcorp.ca  IN  A  10.10.10.1
 zip.bigcorp.ca  IN  A  10.10.10.2
-</code></pre>
+```
 
 The update action can be used to change the Time To Live (TTL) value for a given RR.
 
 E.g.
 
-<pre><code>
+```bash
 (venv) $ bamcli view zip.bigcorp.ca A
 zip.bigcorp.ca  IN  A  10.10.10.1
 
@@ -156,15 +160,13 @@ Updated RR as follows:
 zip.bigcorp.ca  IN  3600 A  10.10.10.1
 (venv) $ bamcli view zip.bigcorp.ca A
 zip.bigcorp.ca  IN  3600 A  10.10.10.1
-</code></pre>
+```
 
-<h3> Viewing DNS data </h3>
+### Viewing DNS data
 
 Now we can VIEW the data we have added. To see the entire zone use the top level domain name followed by a dot. (The output is in BIND format).
 
-
-
-<pre><code>
+```bash
 (venv) $ bamcli view zip.bigcorp.ca<b>.</b>
 zip.bigcorp.ca       IN       A      10.10.1.1
 zip.bigcorp.ca       IN       MX     10 smtp.zip.bigcorp.ca
@@ -174,48 +176,47 @@ red.zip.bigcorp.ca   IN       A      10.10.0.100
 tmp.zip.bigcorp.ca   IN  3600 A      10.10.7.7
 rouge.zip.bigcorp.ca IN       CNAME  red.zip.bigcorp.ca
 note.zip.bigcorp.ca  IN       TXT    "Superman and Batman"
-</code></pre>
+```
 
 To see only the data at the top of the zone drop the trailing dot:
 
-<pre><code>
+```bash
 (venv) $ bamcli view zip.bigcorp.ca
 zip.bigcorp.ca       IN   A      10.10.1.1
 zip.bigcorp.ca       IN   MX     10 smtp.zip.bigcorp.ca
-</code></pre>
+```
 
 To see all data of the same RR type the value can be dropped from the argument list:
 
-
-
-<pre><code>
+```bash
 (venv) $ bamcli view blue.zip.bigcorp.ca A
 blue.zip.bigcorp.ca       IN   A    10.10.10.10
 blue.zip.bigcorp.ca       IN   A    10.10.2.2
-</code></pre>
+```
 
-<h3> Deleting DNS data </h3>
+### Deleting DNS data
 
 Deleting DNS RRs are done in the same manner in which they were added. The general syntax is:
 
-<pre><code>
+```bash
 (venv) $ bamcli delete fqdn RR_type value
-</code></pre>
+```
 
 Here are some examples:
 
-<pre><code>
+```bash
 (venv) $ bamcli delete zip.bigcorp.ca A 10.10.1.1
 (venv) $ bamcli delete blue.zip.bigcorp.ca A 10.10.10.10,10.10.2.2
 (venv) $ bamcli delete rouge.zip.bigcorp.ca CNAME
+```
 
 Note: CNAME records can be deleted with or without the value as there can only be one record per fqdn.
-</code></pre>
+
 
 ## Batch operations
 
 At the present time bulk operations are managed by creating a file of bamcli commands using file as input to the shell.
 
-<pre><code>
+```bash
 (venv) $cat cli-cmds | sh
-</code></pre>
+```

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,117 @@
+# This file is used to configure your project.
+# Read more about the various options under:
+# http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
+
+[metadata]
+name = BlueCat_Address_Manager
+description = BlueCat_Address_Manager is a python interface to the BlueCat Address Manager software (https://www.bluecatnetworks.com/platform/management/bluecat-address-manager/). It offers both an API and a CLI to simplify management of resources in a BlueCat AM installation
+author = Russell Sutherland
+author-email = russell.sutherland@utoronto.ca
+license = apache
+url = https://github.com/quistian/bamcli
+long-description = file: README.md
+long-description-content-type = text/markdown
+# Change if running only on Windows, Mac or Linux (comma-separated)
+platforms = any
+# Add here all kinds of additional classifiers as defined under
+# https://pypi.python.org/pypi?%3Aaction=list_classifiers
+classifiers =
+    Development Status :: 4 - Beta
+    Programming Language :: Python
+
+[options]
+zip_safe = False
+packages = find:
+include_package_data = True
+package_dir =
+    =src
+# DON'T CHANGE THE FOLLOWING LINE! IT WILL BE UPDATED BY PYSCAFFOLD!
+setup_requires = pyscaffold>=3.1a0,<3.2a0
+# Add here dependencies of your project (semicolon/line-separated), e.g.
+install_requires =
+    requests
+    Click
+# The usage of test_requires is discouraged, see `Dependency Management` docs
+# tests_require = pytest; pytest-cov
+# Require a specific Python version, e.g. Python 2.7 or >= 3.4
+# python_requires = >=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*
+
+[options.packages.find]
+where = src
+exclude =
+    tests
+
+[options.extras_require]
+# Add here additional requirements for extra features, to install with:
+# `pip install bamcli[PDF]` like:
+# PDF = ReportLab; RXP
+# Add here test requirements (semicolon/line-separated)
+testing =
+    pytest
+    pytest-cov
+
+[options.entry_points]
+# Add here console scripts like:
+# console_scripts =
+#     script_name = bluecat_am.module:function
+# For example:
+console_scripts =
+    bamcli = bluecat_am.cli:run
+# And any other entry points, for example:
+# pyscaffold.cli =
+#     awesome = pyscaffoldext.awesome.extension:AwesomeExtension
+
+[test]
+# py.test options when running `python setup.py test`
+# addopts = --verbose
+extras = True
+
+[tool:pytest]
+# Options for py.test:
+# Specify command line options as you would do when invoking py.test directly.
+# e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
+# in order to write a coverage file that can be read by Jenkins.
+addopts =
+    --cov bluecat_am --cov-report term-missing
+    --verbose
+norecursedirs =
+    dist
+    build
+    .tox
+testpaths = tests
+
+[aliases]
+build = bdist_wheel
+release = build upload
+
+[bdist_wheel]
+# Use this option if your package is pure-python
+universal = 1
+
+[build_sphinx]
+source_dir = docs
+build_dir = docs/_build
+
+[devpi:upload]
+# Options for the devpi: PyPI server and packaging tool
+# VCS export must be deactivated since we are using setuptools-scm
+no-vcs = 1
+formats = bdist_wheel
+
+[flake8]
+# Some sane defaults for the code style checker flake8
+exclude =
+    .tox
+    build
+    dist
+    .eggs
+    docs/conf.py
+
+[pyscaffold]
+# PyScaffold's parameters when the project was created.
+# This will be used when updating. Do not change!
+version = 3.1
+package = bluecat_am
+extensions =
+    markdown
+    no_skeleton

--- a/setup.py
+++ b/setup.py
@@ -1,17 +1,24 @@
+#!/usr/bin/env python
+# -*- coding: utf-8 -*-
+"""
+    Setup file for bluecat_am.
+    Use setup.cfg to configure your project.
+
+    This file was generated with PyScaffold 3.1.
+    PyScaffold helps you to put up the scaffold of your new Python project.
+    Learn more under: https://pyscaffold.org/
+"""
+import sys
+
+from pkg_resources import require, VersionConflict
 from setuptools import setup
 
-setup(
-        name='BAM CLI Interface',
-        version='0.0.1',
-        description='Python Command Line Interface to BAM',
-        author='Russell Sutherland',
-        author_email='russell.sutherland@utoronto.ca',
-        py_modules=[
-            'requests',
-            'Click',
-        ],
-        entry_points='''
-            [console_scripts]
-            bamcli=bamcli:cli
-        ''',
-)
+try:
+    require('setuptools>=38.3')
+except VersionConflict:
+    print("Error: version of setuptools is too old (<38.3)!")
+    sys.exit(1)
+
+
+if __name__ == "__main__":
+    setup(use_pyscaffold=True)

--- a/src/bluecat_am/__init__.py
+++ b/src/bluecat_am/__init__.py
@@ -1,0 +1,11 @@
+# -*- coding: utf-8 -*-
+from pkg_resources import get_distribution, DistributionNotFound
+
+try:
+    # Change here if project is renamed and does not equal the package name
+    dist_name = 'bamcli'
+    __version__ = get_distribution(dist_name).version
+except DistributionNotFound:
+    __version__ = 'unknown'
+finally:
+    del get_distribution, DistributionNotFound

--- a/src/bluecat_am/api.py
+++ b/src/bluecat_am/api.py
@@ -55,7 +55,6 @@ Global Variables convention:
 
 '''
 
-Debug = True
 Debug = False
 
 BaseURL = ''
@@ -249,6 +248,7 @@ Parameter Description:
 Returns a list of branch items given the root one level up
 
 '''
+
 
 def get_entities(parentid, type, start=0, count=10):
     URL = BaseURL + 'getEntities'

--- a/src/bluecat_am/cli.py
+++ b/src/bluecat_am/cli.py
@@ -1,5 +1,6 @@
+from bluecat_am import api
+
 import click
-import pybam
 
 @click.command()
 
@@ -16,14 +17,14 @@ import pybam
 
 # Main programme
 
-def cli(action, fqdn, rr_type, value, ttl, debug):
+def run(action, fqdn, rr_type, value, ttl, debug):
     '''
     Command line interface to BAM DNS System \n
     Usage: action fqdn rr_type ttl value \n
     E.g.  $ add bozo.uoft.ca A 3600 10.10.10.1 [TTL]
     '''
 
-    pybam.bam_init(debug)
+    api.bam_init(debug)
 
     if debug:
         click.echo('action: {}'.format(action))
@@ -36,45 +37,45 @@ def cli(action, fqdn, rr_type, value, ttl, debug):
         elif rr_type == 'A':
             ips = value.split(',')
             for ip in ips:
-                pybam.add_rr(fqdn, rr_type, ip, ttl)
+                api.add_rr(fqdn, rr_type, ip, ttl)
         else:
-                pybam.add_rr(fqdn, rr_type, value, ttl)
+                api.add_rr(fqdn, rr_type, value, ttl)
     elif action == 'replace' or action == 'update':
         if rr_type == 'defRR' or value == 'defVAL':
             print('Not enough RR information given')
             print('Format: bamcli {} fqdn RR_type value'.format(action))
         else:
-            pybam.update_rr(fqdn, rr_type, value, ttl)
+            api.update_rr(fqdn, rr_type, value, ttl)
     elif action == 'delete' or action == 'remove':
         if rr_type == 'defRR':
             print('No RR type information given')
         elif rr_type == 'CNAME':
-            pybam.delete_rr(fqdn, rr_type)
+            api.delete_rr(fqdn, rr_type)
         elif value != 'defVAL':
             if rr_type == 'A':
                 for val in value.split(','):
-                    pybam.delete_rr(fqdn, rr_type, val)    
+                    api.delete_rr(fqdn, rr_type, val)    
             else:
-                pybam.delete_rr(fqdn, rr_type, value)
+                api.delete_rr(fqdn, rr_type, value)
         else:
             print('Not enough RR information given')
             print('Format: bamcli {} fqdn RR_type value'.format(action))
     elif action == 'view' or action == 'list':
         if rr_type == 'defRR':
-            pybam.view_rr(fqdn)
+            api.view_rr(fqdn)
         elif value == 'defVAL':
-            pybam.view_rr(fqdn, rr_type)
+            api.view_rr(fqdn, rr_type)
         else:
-            pybam.view_rr(fqdn, rr_type, value)
+            api.view_rr(fqdn, rr_type, value)
     elif action == 'find':
         if rr_type == 'defRR':
-            ids = pybam.find_rr(fqdn)
+            ids = api.find_rr(fqdn)
         elif value == 'defVAL':
-            ids = pybam.find_rr(fqdn, rr_type)
+            ids = api.find_rr(fqdn, rr_type)
         else:
-            ids = pybam.find_rr(fqdn, rr_type, value)
+            ids = api.find_rr(fqdn, rr_type, value)
         print(ids)
 
 
 if __name__ == '__main__':
-    cli()
+    run()


### PR DESCRIPTION
Hi Russell, in the below commits I've made a number of changes to align your project with some industry standards. Here's an outline of the changes and their reasons:

CHANGE: replace setup.py with setup.cfg, leveraging the PyScaffold packaging tool
REASON: The PyScaffold model is one of the most popular methods for maintaining python packaging best practices in terms of managing metadata, dev dependencies, and package dependencies. The benefits of this approach are numerous (see [PyScaffold](https://pyscaffold.readthedocs.io/en/latest/features.html) for details), but the big ones for this project are:
 - Any user who downloads this project can do a `pip install -e .` and pip will automatically install all project dependencies
 - This setup.cfg file is configured to leverage git for versioning. A common industry best-practice is to tag all python package releases in git with a tag representing the version number. (ex. you release a version 0.0.2 of the bamcli, you tag the git repo at that exact moment with a tag v0.0.2). That way, anyone can at any point in time easily go back to the source code exactly as it was when that version of the package was published. Normally, this is a two-step process (increase the version number in setup.py / setup.cfg, then git tag the repo with that version) This particular setup.py file automatically infers the package version from the git tag, so that any time you create a git tag containing a version number (v0.0.2 for example), the version of the python package will automatically update, saving you an extra step
 - If this project were to be built into a distributable package and published to a package index like PYPI, the contents of the README would be included in the long description. you don't need to maintain a separate copy of the README just for PYPI
 - all development metadata for the package and the development environmnet, and any future documentation and testing tooling you might use are all in one place, easy to manage

CHANGE: replace HTML code in the README with markdown
REASON: markdown syntax confers a number of benefits over HTML:
 - It's easier to read and write in its raw form
 - When section headers are expressed in markdown instead of HTML, it's easier for all markdown processors to parse them and infer document structure. HTML is only useful for web broswers. markdown is useful for web browsers (through auto-renderers like github), as well as terminal markdown viewers, table-of-contents generators, etc
 - when code blocks are expressed as markdown, it's possibly to automatically enable language-aware syntax highlighting in all mardown viewers by specifying (in markdown) what language a code block is written in

CHANGE: rename bamcli.py and pybam.py to bluecat_am.cli and bluecat_am.api
REASON: converting these two scripts into modules in a python package will make it much easier to maintain the code as it grows in size and complexity. making this change early, before it becomes absolutely necessary, will save a lot of headaches in the future. naming the modules cli and api makes it very clear to all what each of these modules does. This will make it easier for any external developers wishing to use the api without the cli to do so.

CHANGE: move the bluecat_am package into a src/ folder
REASON: if / when you start writing automatic tests for this project (using pytest or nose or unittests), you will most likely eventually come to a situation where your tests will fail to capture a certain class of bugs that may crop up in the wild. Isolating your package "bluecat_am" from your project folder solves these problems. For more details on the whys and hows, i suggest reading this excellent [blog post](https://blog.ionelmc.ro/2014/05/25/python-packaging/#the-structure)

CHANGE: add a .gitignore
REASON: as different developers with different tool chains and environments start working on and modifying the project, they will each use tools that add certain developer-specific of machine-specific or build-artifact-specific files to the project folder, files which do not belong in version control. This .gitignore files covers all the most common of these file types for a variety of python development workflows

I hope you find these changes as useful as I do. If you have any questions, please let me know.

Thanks