### PR TITLE
Suggestion for CLI: Refactor variadic command into Click command group, set up tests

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,7 +3,7 @@
 # http://setuptools.readthedocs.io/en/latest/setuptools.html#configuring-setup-using-setup-cfg-files
 
 [metadata]
-name = BlueCat_Address_Manager
+name = BlueCat-Address-Manager
 description = BlueCat_Address_Manager is a python interface to the BlueCat Address Manager software (https://www.bluecatnetworks.com/platform/management/bluecat-address-manager/). It offers both an API and a CLI to simplify management of resources in a BlueCat AM installation
 author = Russell Sutherland
 author-email = russell.sutherland@utoronto.ca
@@ -72,7 +72,7 @@ extras = True
 # e.g. --cov-report html (or xml) for html/xml output or --junitxml junit.xml
 # in order to write a coverage file that can be read by Jenkins.
 addopts =
-    --cov bluecat_am --cov-report term-missing
+    #--cov bluecat_am --cov-report term-missing
     --verbose
 norecursedirs =
     dist

--- a/src/bluecat_am/cli.py
+++ b/src/bluecat_am/cli.py
@@ -1,7 +1,9 @@
 import re
 import click
-from bluecat_am import config
-from bluecat_am import util
+from click import group, pass_context, option, argument
+from click import Context
+from bluecat_am import util, config
+
 
 def validate_fqdn(ctx, param, value):
     pattern = '[\w]+(\.[\w]+)+'
@@ -9,93 +11,193 @@ def validate_fqdn(ctx, param, value):
         raise click.BadParameter('Value must be in the form: hobo.utoronto.ca')
     return value
 
+
 def validate_value(ctx, param, value):
     return value
 
-@click.command()
 
-@click.option(
-        '-v', '--verbose', is_flag=True,
-        help='Show what is going on for debugging purposes')
-
-@click.argument('action',
-                type=click.Choice(['view', 'add', 'delete', 'modify']),
-                required=True)
-@click.argument('fqdn', type=click.STRING,
-                required=True,
-                callback=validate_fqdn)
-@click.argument('rr_type',
-                type=click.Choice(['A', 'MX', 'CNAME', 'TXT', 'defRR']),
-                default='defRR')
-@click.argument('value', type=click.STRING, default='defVAL',
-                callback=validate_value)
-@click.argument('ttl', type=click.STRING, default='86400')
-
-
-# Main programme
-
-def run(action, fqdn, rr_type, value, ttl, verbose):
+@group()
+@option(
+    '-v', '--verbose',
+    is_flag=True,
+    help='Show what is going on for debugging purposes'
+)
+@pass_context
+def run(ctx: Context, verbose):
     """ Command line interface to BAM DNS System\n
-    Usage: bamcli action fqdn rr_type ttl value\n
-    E.g.  $ add bozo.uoft.ca A 3600 10.10.10.1 [TTL]
+    E.g.  $bamcli add bozo.uoft.ca A 3600 10.10.10.1 [TTL]
     """
 
+    ctx.obj = dict()
+    ctx.obj['DEBUG'] = verbose
     config.Debug = verbose
 
     if verbose:
-        click.echo('action: {}'.format(action))
-        click.echo('    fqdn: {} rr_type: {} value: {}'.format(fqdn,rr_type,value))
-        click.echo()
+        click.echo('action: {}'.format(ctx.invoked_subcommand))
 
     util.bam_init()
 
 
-    if action == 'add':
-        if rr_type == 'defRR' or value == 'defVAL':
-            print('Not enough RR information given')
-            print('Format: bamcli {} fqdn RR_type value [ttl]'.format(action))
-        elif rr_type == 'A':
-            ips = value.split(',')
-            for ip in ips:
-                util.add_rr(fqdn, rr_type, ip, ttl)
+# Define common options to share between subcommands
+fqdn = argument(
+    'fqdn',
+    type=click.STRING,
+    required=True,
+    callback=validate_fqdn,
+)
+SUPPORTED_RR_TYPES = ['A', 'MX', 'CNAME', 'TXT', 'defRR']
+rr_type = argument(
+    'rr_type',
+    type=click.Choice(SUPPORTED_RR_TYPES),
+    default='defRR',
+)
+value = argument(
+    'value',
+    type=click.STRING,
+    default='defVAL',
+    callback=validate_value,
+)
+ttl = argument(
+    'ttl',
+    type=click.STRING,
+    default='86400',
+)
+# @run commands: add, replace, delete, view, find
+
+
+@run.command()
+@pass_context
+@fqdn
+@rr_type
+@value
+@ttl
+def add(ctx, fqdn, rr_type, value, ttl):
+    """Add a new Resource Record to the BlueCat DNS system"""
+    if ctx.obj['DEBUG']:
+        click.echo('    fqdn: {} rr_type: {} value: {}\n'.format(fqdn, rr_type, value))
+
+    if rr_type == 'defRR' or value == 'defVAL':
+        print('Not enough RR information given')
+        print('Format: bamcli {} fqdn RR_type value [ttl]'.format(ctx.command.name))
+    elif rr_type == 'A':
+        ips = value.split(',')
+        for ip in ips:
+            util.add_rr(fqdn, rr_type, ip, ttl)
+    else:
+        util.add_rr(fqdn, rr_type, value, ttl)
+
+
+@run.command()
+@pass_context
+@fqdn
+@rr_type
+@value
+@ttl
+def update(ctx, fqdn, rr_type, value, ttl):
+    """Update a Resource Record in the BlueCat DNS System"""
+    if ctx.obj['DEBUG']:
+        click.echo('    fqdn: {} rr_type: {} value: {}\n'.format(fqdn, rr_type, value))
+
+    if rr_type == 'defRR' or value == 'defVAL':
+        print('Not enough RR information given')
+        print('Format: bamcli {} fqdn RR_type value'.format(ctx.command.name))
+    else:
+        util.update_rr(fqdn, rr_type, value, ttl)
+
+
+@run.command()
+@pass_context
+@fqdn
+@rr_type
+@value
+@ttl
+def replace(ctx, *args, **kwargs):
+    """Alias for the 'update' command"""
+    ctx.forward(update)
+
+
+@run.command()
+@pass_context
+@fqdn
+@rr_type
+@value
+def delete(ctx, fqdn, rr_type, value):
+    """Delete a Resource Record in the BlueCat DNS System"""
+    if ctx.obj['DEBUG']:
+        click.echo('    fqdn: {} rr_type: {} value: {}\n'.format(fqdn, rr_type, value))
+    if rr_type == 'defRR':
+        print('No RR type information given')
+    elif rr_type == 'CNAME':
+        util.delete_rr(fqdn, rr_type)
+    elif value != 'defVAL':
+        if rr_type == 'A':
+            for val in value.split(','):
+                util.delete_rr(fqdn, rr_type, val)
         else:
-                util.add_rr(fqdn, rr_type, value, ttl)
-    elif action == 'replace' or action == 'update':
-        if rr_type == 'defRR' or value == 'defVAL':
-            print('Not enough RR information given')
-            print('Format: bamcli {} fqdn RR_type value'.format(action))
-        else:
-            util.update_rr(fqdn, rr_type, value, ttl)
-    elif action == 'delete' or action == 'remove':
-        if rr_type == 'defRR':
-            print('No RR type information given')
-        elif rr_type == 'CNAME':
-            util.delete_rr(fqdn, rr_type)
-        elif value != 'defVAL':
-            if rr_type == 'A':
-                for val in value.split(','):
-                    util.delete_rr(fqdn, rr_type, val)    
-            else:
-                util.delete_rr(fqdn, rr_type, value)
-        else:
-            print('Not enough RR information given')
-            print('Format: bamcli {} fqdn RR_type value'.format(action))
-    elif action == 'view' or action == 'list':
-        if rr_type == 'defRR':
-            util.view_rr(fqdn)
-        elif value == 'defVAL':
-            util.view_rr(fqdn, rr_type)
-        else:
-            util.view_rr(fqdn, rr_type, value)
-    elif action == 'find':
-        if rr_type == 'defRR':
-            ids = util.find_rr(fqdn)
-        elif value == 'defVAL':
-            ids = util.find_rr(fqdn, rr_type)
-        else:
-            ids = util.find_rr(fqdn, rr_type, value)
-        print(ids)
+            util.delete_rr(fqdn, rr_type, value)
+    else:
+        print('Not enough RR information given')
+        print('Format: bamcli {} fqdn RR_type value'.format(ctx.command.name))
+
+
+@run.command()
+@pass_context
+@fqdn
+@rr_type
+@value
+def remove(ctx, *args, **kwargs):
+    """Alias for the 'delete' command"""
+    ctx.forward(delete)
+
+
+@run.command()
+@pass_context
+@fqdn
+@rr_type
+@value
+def view(ctx, fqdn, rr_type, value):
+    """View a Resource Record in the BlueCat DNS System"""
+    if ctx.obj['DEBUG']:
+        click.echo('    fqdn: {} rr_type: {} value: {}\n'.format(fqdn, rr_type, value))
+
+    if rr_type == 'defRR':
+        util.view_rr(fqdn)
+    elif value == 'defVAL':
+        util.view_rr(fqdn, rr_type)
+    else:
+        util.view_rr(fqdn, rr_type, value)
+
+
+# Set custom command name so that function name doesn't override python builtin `list` function
+@run.command('list')
+@pass_context
+@fqdn
+@rr_type
+@value
+def list_rr(ctx, *args, **kwargs):
+    """Alias for the 'view' command"""
+    ctx.forward(view)
+
+
+@run.command()
+@pass_context
+@fqdn
+@rr_type
+@value
+def find(ctx, fqdn, rr_type, value):
+    """Find a Resource Record in the BlueCat DNS System"""
+    if ctx.obj['DEBUG']:
+        click.echo('    fqdn: {} rr_type: {} value: {}\n'.format(fqdn, rr_type, value))
+
+    if rr_type == 'defRR':
+        ids = util.find_rr(fqdn)
+    elif value == 'defVAL':
+        ids = util.find_rr(fqdn, rr_type)
+    else:
+        ids = util.find_rr(fqdn, rr_type, value)
+    print(ids)
 
 
 if __name__ == '__main__':
-    run()
+    run(['add', 'alex.utoronto.ca', 'A', '10.128.30.40'])
+    pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,95 @@
+from click.testing import CliRunner
+from bluecat_am.cli import run
+
+
+VALID_IPS = ['10.128.0.10', '10.128.0.20', '10.128.0.30']
+INVALID_IP = '10.20.30.40'
+VALID_DOMAIN = 'alex.utoronto.ca'
+INVALID_DOMAIN = 'something.some.thing'
+NONEXIST_DOMAIN = 'blah.alex.utoronto.ca'
+
+
+def test_cli_command_group():
+    """Test to make sure subcommands show up in """
+    print()
+    cli = CliRunner()
+    cmd = '--help'
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+
+
+def test_multiple_A_records():
+    print()
+    cli = CliRunner()
+    cmd = 'add {} A {}'.format(VALID_DOMAIN, VALID_IPS[0])
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+    cmd = 'add {} A {}'.format(VALID_DOMAIN, VALID_IPS[1])
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+    cmd = 'add {} A {}'.format(VALID_DOMAIN, VALID_IPS[2])
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+    cmd = 'view alex.utoronto.ca A'
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+    cmd = 'find {} A'.format(VALID_DOMAIN)
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+    cmd = 'delete {} A {}'.format(VALID_DOMAIN, VALID_IPS[2])
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+    cmd = 'delete {} A {}'.format(VALID_DOMAIN, VALID_IPS[1])
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+    cmd = 'delete {} A {}'.format(VALID_DOMAIN, VALID_IPS[0])
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+
+
+def test_add_ip_outside_valid_network():
+    print()
+    cli = CliRunner()
+    cmd = 'add {} A {}'.format(VALID_DOMAIN, INVALID_IP)
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+
+
+def test_add_fqdn_outside_range():
+    print()
+    cli = CliRunner()
+    cmd = 'add {} A {}'.format(INVALID_DOMAIN, VALID_IPS[0])
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)
+
+
+def test_delete_non_existant_FQDN():
+    print()
+    cli = CliRunner()
+    cmd = 'delete {} A {}'.format(NONEXIST_DOMAIN, VALID_IPS[0])
+    result = cli.invoke(run, cmd)
+    print("Ran 'bamcli {}'".format(cmd))
+    print("Got:")
+    print(result.stdout)


### PR DESCRIPTION
Hi Russell, Here's my proposal for refactoring the CLI.

Currently, the CLI is one click command. I say it's a variadic command, because it's a command that does completely different things depending on its arguments (ie, what 'action' argument you call it with)
What I'm suggesting to do here is to break it up into a set of different commands in a command group. This gives us a number of benefits, some of which are outlined below:
 - Simplifies the CLI code. Each action type has its own function and can focus one what it does best, can have its own set or combination of input arguments, and can do its own validation of those arguments.
 - Enables future support for shell completion (ie. bash tab completion of zsh completion)
 - Makes it easier to separate global command-line options (like `--verbose` and `--silent` with command-specific options and arguments)
 - Makes it easier to test individual commands in isolation

Another change included in this proposal is that I'm set up preliminary test scenarios to test the CLI and define expected behaviour. These tests are written to be run with `pytest` (`pip install pytest`), which is a common and popular python testing framework.

Right now these tests don't make any kind of assertions about expected behaviour, so they're not what I would call 'complete', but they do print out the commands they run and the results they get in different scenarios, and so they're very useful in highlighting how the CLI currently behaves.